### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -49,7 +49,7 @@
 #'   number. \item r Attendances seen within 4 hours. \item n Total number of 
 #'   attendances. }
 #' @source Mohammed MA, et al. Quality and Safety in Health Care
-#'   2013;22:362–368. \url{http://dx.doi.org/10.1136/bmjqs-2012-001373}
+#'   2013;22:362–368. \url{https://doi.org/10.1136/bmjqs-2012-001373}
 "nhs_accidents"
 
 #' Patient harm indentified using the Global Trigger Tool

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Non-random variation in the form of minor to moderate persistent shifts in data over time is identified by the Anhoej rules for unusually long runs and unusually few crossing [Anhoej, Olesen (2014) https://doi.org/10.1371/journal.pone.0113825].
 
-Non-random variation in the form of larger, possibly transient, shifts is identified by Shewhart's 3-sigma rule [Mohammed, Worthington, Woodall (2008) http://dx.doi.org/10.1136/qshc.2004.012047].
+Non-random variation in the form of larger, possibly transient, shifts is identified by Shewhart's 3-sigma rule [Mohammed, Worthington, Woodall (2008) https://doi.org/10.1136/qshc.2004.012047].
 
 ## Exported functions
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@
 <a href="#quality-improvement-charts-for-r" class="anchor"></a>Quality improvement charts for R</h1></div>
 <p><code>qicharts2</code> is an R package with functions for making run charts, Shewhart control charts and Pareto charts for continuous quality improvement. Included control charts are: I, MR, Xbar, S, T, C, U, U’, P, P’, and G charts.</p>
 <p>Non-random variation in the form of minor to moderate persistent shifts in data over time is identified by the Anhoej rules for unusually long runs and unusually few crossing [Anhoej, Olesen (2014) <a href="https://doi.org/10.1371/journal.pone.0113825" class="uri">https://doi.org/10.1371/journal.pone.0113825</a>].</p>
-<p>Non-random variation in the form of larger, possibly transient, shifts is identified by Shewhart’s 3-sigma rule [Mohammed, Worthington, Woodall (2008) <a href="http://dx.doi.org/10.1136/qshc.2004.012047" class="uri">http://dx.doi.org/10.1136/qshc.2004.012047</a>].</p>
+<p>Non-random variation in the form of larger, possibly transient, shifts is identified by Shewhart’s 3-sigma rule [Mohammed, Worthington, Woodall (2008) <a href="https://doi.org/10.1136/qshc.2004.012047" class="uri">https://doi.org/10.1136/qshc.2004.012047</a>].</p>
 <div id="exported-functions" class="section level2">
 <h2 class="hasAnchor">
 <a href="#exported-functions" class="anchor"></a>Exported functions</h2>

--- a/docs/reference/nhs_accidents.html
+++ b/docs/reference/nhs_accidents.html
@@ -119,7 +119,7 @@ weeks.</p>
     <h2 class="hasAnchor" id="source"><a class="anchor" href="#source"></a>Source</h2>
 
     <p>Mohammed MA, et al. Quality and Safety in Health Care
-  2013;22:362–368. <a href='http://dx.doi.org/10.1136/bmjqs-2012-001373'>http://dx.doi.org/10.1136/bmjqs-2012-001373</a></p>
+  2013;22:362–368. <a href='https://doi.org/10.1136/bmjqs-2012-001373'>https://doi.org/10.1136/bmjqs-2012-001373</a></p>
     
 
   </div>

--- a/man/nhs_accidents.Rd
+++ b/man/nhs_accidents.Rd
@@ -9,7 +9,7 @@
   attendances. }}
 \source{
 Mohammed MA, et al. Quality and Safety in Health Care
-  2013;22:362–368. \url{http://dx.doi.org/10.1136/bmjqs-2012-001373}
+  2013;22:362–368. \url{https://doi.org/10.1136/bmjqs-2012-001373}
 }
 \usage{
 nhs_accidents


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!