### PR TITLE
Prime correction - screen moving ranges before calculation

### DIFF
--- a/R/helper.functions.R
+++ b/R/helper.functions.R
@@ -5,7 +5,7 @@ runs.analysis <- function(x, method) {
   runs               <- runs[runs != 0 & !is.na(runs)]
   n.useful           <- length(runs)
   n.obs <- length(y)
-  
+
   if (n.useful) {
     run.lengths      <- rle(runs)$lengths
     n.runs           <- length(run.lengths)
@@ -35,31 +35,31 @@ runs.analysis <- function(x, method) {
   x$longest.run.max <- longest.run.max
   x$n.crossings     <- n.crossings
   x$n.crossings.min <- n.crossings.min
-  
+
   return(x)
 }
 
 crsignal <- function(n, c, l, method = c('anhoej', 'bestbox', 'cutbox')) {
   method <- match.arg(method)
-  
+
   if (!(method %in% c('anhoej', 'bestbox', 'cutbox')))
     stop('method should be \"anhoej\", \"bestbox\", or \"cutbox\"')
-  
+
   if ((n < 10 | n > 100) & method != 'anhoej') {
     message('Best box and cut box computations only available for n between ',
             '10 and 100. Using method = "anhoej"')
     method <- 'anhoej'
   }
-  
+
   if(method != 'anhoej')
     message('Runs analysis using ', method, ' method')
-  
+
   if (!(c %in% c(0:n - 1)))
     stop('c should be an integer between 0 and ', n - 1)
-  
+
   if (!(l %in% c(1:n)))
     stop('l should be an integer between 1 and ', n)
-  
+
   bounds <- data.frame(
     n = 10:100,
     cb    = c(  2,  3,  3,  3,  3,  4,  5,  5,  5,  5,  6,  7,  6,
@@ -67,32 +67,32 @@ crsignal <- function(n, c, l, method = c('anhoej', 'bestbox', 'cutbox')) {
                 13, 14, 13, 15, 15, 15, 14, 14, 17, 17, 17, 17, 19,
                 19, 19, 19, 19, 21, 21, 21, 21, 23, 23, 23, 23, 23,
                 25, 25, 26, 26, 27, 27, 27, 28, 29, 29, 29, 30, 30,
-                31, 31, 31, 32, 33, 33, 33, 34, 33, 35, 35, 35, 35, 
+                31, 31, 31, 32, 33, 33, 33, 34, 33, 35, 35, 35, 35,
                 37, 37, 38, 37, 39, 39, 39, 39, 39, 41, 41, 42, 41),
     lb    = c(  6,  7,  6,  6,  6,  7,  8,  7,  7,  7,  7,  8,  7,
                 7,  7,  7,  9,  8,  8,  8, 10,  9,  8,  8,  8,  8,
                 9, 10,  8, 11,  9,  9,  8,  8, 10,  9,  9,  9, 12,
                 10,  9,  9,  9, 11, 10,  9,  9, 12, 10, 10,  9,  9,
                 11, 10, 11, 10, 12, 10, 10, 11, 14, 11, 10, 11, 10,
-                12, 11, 10, 11, 13, 11, 10, 11, 10, 11, 11, 10, 10, 
-                12, 11, 12, 10, 13, 11, 11, 10, 10, 12, 11, 12, 10), 
+                12, 11, 10, 11, 13, 11, 10, 11, 10, 11, 11, 10, 10,
+                12, 11, 12, 10, 13, 11, 11, 10, 10, 12, 11, 12, 10),
     cbord = c(  3,  4, NA, NA, NA,  6,  6, NA,  6,  6, NA, NA,  7,
-                7,  7, NA, 10, 10, 11, NA, 12, 14, NA, 12, 13, NA, 
-                15, NA, NA, NA, NA, 17, NA, NA, NA, NA, 19, 20, 20, 
+                7,  7, NA, 10, 10, 11, NA, 12, 14, NA, 12, 13, NA,
+                15, NA, NA, NA, NA, 17, NA, NA, NA, NA, 19, 20, 20,
                 21, NA, 21, 21, 23, 23, NA, 23, 25, 24, 26, NA, 24,
-                27, 27, 27, 27, 29, NA, 29, 29, 30, 31, 30, 31, NA, 
-                32, 34, 33, 33, 37, 35, NA, 36, 36, NA, 38, 36, 38, 
+                27, 27, 27, 27, 29, NA, 29, 29, 30, 31, 30, 31, NA,
+                32, 34, 33, 33, 37, 35, NA, 36, 36, NA, 38, 36, 38,
                 38, 39, NA, 39, 41, 40, 42, NA, 41, 42, 44, 43, 42),
     lbord = c(  5,  6, NA, NA, NA,  6,  7, NA,  6,  5, NA, NA,  6,
                 6,  6, NA,  7,  7,  7, NA,  9,  8, NA,  7,  7, NA,
-                8, NA, NA, NA, NA,  8, NA, NA, NA, NA,  8,  7, 11, 
+                8, NA, NA, NA, NA,  8, NA, NA, NA, NA,  8,  7, 11,
                 9, NA,  8,  7,  9,  8, NA,  8, 11,  9,  8, NA,  8,
                 9,  9, 10,  9, 10, NA,  8,  8, 13,  9,  9, 10, NA,
                 9,  8,  9,  8, 11,  9, NA, 10,  7, NA,  8,  9,  8,
                 10,  9, NA,  9, 12, 10,  8, NA,  8,  9,  9, 10,  9))
-  
+
   res <- FALSE
-  
+
   if (method == 'anhoej') {
     can <- stats::qbinom(0.05, n - 1, 0.5)
     lan <- round(log2(n)) + 3
@@ -120,7 +120,7 @@ crsignal <- function(n, c, l, method = c('anhoej', 'bestbox', 'cutbox')) {
         res <- FALSE
     }
   }
-  
+
   return(res)
 }
 
@@ -132,7 +132,7 @@ qic.run <- function(x) {
   x$ucl.95 <- as.numeric(NA)
   x$lcl <- as.numeric(NA)
   x$lcl.95 <- as.numeric(NA)
-  
+
   return(x)
 }
 
@@ -140,57 +140,57 @@ qic.i <- function(x) {
   base <- x$baseline & x$include
   if (anyNA(x$cl))
     x$cl <- mean(x$y[base], na.rm = TRUE)
-  
+
   # Average moving range
   mr  <- abs(diff(x$y[base] - x$cl[base]))
   amr <- mean(mr, na.rm = TRUE)
-  
+
   # Upper limit for moving ranges
   ulmr <- 3.267 * amr
-  
+
   # Remove moving ranges greater than ulmr and recalculate amr, Nelson 1982
   mr  <- mr[mr < ulmr]
   amr <- mean(mr, na.rm = TRUE)
-  
+
   # Calculate standard deviation, Montgomery, 6.33
   stdev <- amr / 1.128
-  
+
   # Calculate control limits
   x$lcl <- x$cl - 3 * stdev
   x$lcl.95 <- x$cl - 2 * stdev
   x$ucl <- x$cl + 3 * stdev
   x$ucl.95 <- x$cl + 2 * stdev
-  
+
   return(x)
 }
 
 qic.mr <- function(x) {
   base <- x$baseline & x$include
   x$y  <- c(NA, abs(diff(x$y)))
-  
+
   # Calculate centre line
   if (anyNA(x$cl))
     x$cl <- mean(x$y[base], na.rm = TRUE)
-  
+
   # Calculate upper limit for moving ranges
   x$lcl <- 0
   x$lcl.95 <- 0
   x$ucl <- 3.267 * x$cl
   x$ucl.95 <- (3.267 / 3) * 2 * x$cl
-  
+
   return(x)
 }
 
 qic.xbar <- function(x){
   base  <- x$baseline & x$include
   var.n <- as.logical(length(unique(x$y.length)) - 1)
-  
+
   # Calculate centre line, Montgomery 6.30
   if (anyNA(x$cl)) {
     x$cl <- sum(x$y.length[base] * x$y.mean[base], na.rm = TRUE) /
       sum(x$y.length[base], na.rm = TRUE)
   }
-  
+
   # Calculate standard deviation and control limits, Montgomery 6.29 or 6.31
   if (var.n) {
     stdev <- sqrt(sum((x$y.length[base] - 1) * x$y.sd[base]^2, na.rm = TRUE) /
@@ -204,7 +204,7 @@ qic.xbar <- function(x){
   x$ucl.95 <- x$cl + A3.95 * stdev
   x$lcl <- x$cl - A3 * stdev
   x$lcl.95 <- x$cl - A3.95 * stdev
-  
+
   return(x)
 }
 
@@ -212,7 +212,7 @@ qic.s <- function(x){
   base  <- x$baseline & x$include
   var.n <- as.logical(length(unique(x$y.length)) - 1)
   x$y   <- x$y.sd
-  
+
   # Calculate centre line and control limits
   if (anyNA(x$cl)) {
     if (var.n) { # Variable subgroup size: Montgomery 6.31
@@ -230,7 +230,7 @@ qic.s <- function(x){
   x$ucl.95  <- B4.95 * x$cl
   x$lcl     <- B3 * x$cl
   x$lcl.95  <- B3.95 * x$cl
-  
+
   return(x)
 }
 
@@ -238,11 +238,11 @@ qic.t <- function(x) {
   if (min(x$y, na.rm = TRUE) <= 0) {
     stop('Time between events must be greater than zero')
   }
-  
+
   # Transform y variable and run I chart calculations
   x$y <- x$y^(1 / 3.6)
   x   <- qic.i(x)
-  
+
   # Back transform centre line and control limits
   x$y   <- x$y^3.6
   x$cl  <- x$cl^3.6
@@ -251,21 +251,21 @@ qic.t <- function(x) {
   x$lcl <- x$lcl^3.6
   x$lcl.95 <- x$lcl.95^3.6
   x$lcl[x$lcl < 0 | is.nan(x$lcl)] <- 0
-  
+
   return(x)
 }
 
 qic.p <- function(x) {
   base <- x$baseline & x$include
-  
+
   if (anyNA(x$cl)) {
     x$cl <- sum(x$y.sum[base], na.rm = TRUE) /
       sum(x$n[base], na.rm = TRUE)
   }
-  
+
   # Calculate standard deviation
   stdev <- sqrt(x$cl * (1 - x$cl) / x$n)
-  
+
   # Calculate control limits
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
@@ -275,33 +275,45 @@ qic.p <- function(x) {
   x$ucl.95[x$ucl.95 > 1 & is.finite(x$ucl.95)] <- 1
   x$lcl[x$lcl < 0 & is.finite(x$lcl)] <- 0
   x$lcl.95[x$lcl.95 < 0 & is.finite(x$lcl.95)] <- 0
-  
+
   return(x)
 }
 
 qic.pp <- function(x) {
   base <- x$baseline & x$include
-  
+
   if (anyNA(x$cl)) {
     x$cl <- sum(x$y.sum[base], na.rm = TRUE) /
       sum(x$n[base], na.rm = TRUE)
   }
-  
+
   # Calculate standard deviation
   stdev <- sqrt(x$cl * (1 - x$cl) / x$n)
-  
+
   # Calculate standard deviation for Laney's P prime chart, incorporating
   # between-subgroup variation.
   z_i     <- (x$y[base] - x$cl[base]) / stdev[base]
   # TESTING ##############################################
-  if(is.factor(x$x) || is.character(x$x))
+  if(is.factor(x$x) || is.character(x$x)) {
     sigma_z <- stats::sd(z_i)
-  else
-    sigma_z <- mean(abs(diff(z_i)), na.rm = TRUE) / 1.128
-  # TESTING ##############################################  
-  
+  }
+  else {
+    mr  <- abs(diff(z_i))
+    amr <- mean(mr, na.rm = TRUE)
+
+    # Upper limit for moving ranges
+    ulmr <- 3.267 * amr
+
+    # Remove moving ranges greater than ulmr and recalculate amr, Nelson 1982
+    mr  <- mr[mr < ulmr]
+    amr <- mean(mr, na.rm = TRUE)
+
+    sigma_z <- amr / 1.128
+  }
+  # TESTING ##############################################
+
   stdev   <- stdev * sigma_z
-  
+
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
   x$lcl          <- x$cl - 3 * stdev
@@ -310,21 +322,21 @@ qic.pp <- function(x) {
   x$ucl.95[x$ucl.95 > 1 & is.finite(x$ucl.95)] <- 1
   x$lcl[x$lcl < 0 & is.finite(x$lcl)] <- 0
   x$lcl.95[x$lcl.95 < 0 & is.finite(x$lcl.95)] <- 0
-  
+
   return(x)
 }
 
 qic.c <- function(x){
   base <- x$baseline & x$include
   x$y <- x$y.sum
-  
+
   if (anyNA(x$cl)) {
     x$cl <- mean(x$y[base], na.rm = TRUE)
   }
-  
+
   # Calculate standard deviation, Montgomery 7.17
   stdev <- sqrt(x$cl)
-  
+
   # Calculate control limits
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
@@ -332,20 +344,20 @@ qic.c <- function(x){
   x$lcl.95       <- x$cl - 2 * stdev
   x$lcl[x$lcl < 0 & is.finite(x$lcl)] <- 0
   x$lcl.95[x$lcl.95 < 0 & is.finite(x$lcl.95)] <- 0
-  
+
   return(x)
 }
 
 qic.u <- function(x){
   base <- x$baseline & x$include
-  
+
   if (anyNA(x$cl)) {
     x$cl   <- sum(x$y.sum[base], na.rm = TRUE) / sum(x$n[base], na.rm = TRUE)
   }
-  
+
   # Calculate standard deviation, Montgomery 7.19
   stdev <- sqrt(x$cl / x$n)
-  
+
   # Calculate control limits
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
@@ -353,34 +365,46 @@ qic.u <- function(x){
   x$lcl.95       <- x$cl - 2 * stdev
   x$lcl[x$lcl < 0 & is.finite(x$lcl)] <- 0
   x$lcl.95[x$lcl.95 < 0 & is.finite(x$lcl.95)] <- 0
-  
+
   return(x)
 }
 
 qic.up <- function(x){
   base <- x$baseline & x$include
-  
+
   if (anyNA(x$cl)) {
     x$cl   <- sum(x$y.sum[base], na.rm = TRUE) / sum(x$n[base], na.rm = TRUE)
   }
-  
+
   # Calculate standard deviation, Montgomery 7.19
   stdev <- sqrt(x$cl / x$n)
-  
+
   # Calculate standard deviation for Laney's u-prime chart, incorporating
   # between-subgroup variation.
   z_i     <- (x$y[base] - x$cl[base]) / stdev[base]
-  
+
   # TESTING ##############################################
   # sigma_z <- mean(abs(diff(z_i)), na.rm = TRUE) / 1.128
-  if(is.factor(x$x) || is.character(x$x))
+  if(is.factor(x$x) || is.character(x$x)) {
     sigma_z <- stats::sd(z_i)
-  else
-    sigma_z <- mean(abs(diff(z_i)), na.rm = TRUE) / 1.128
-  # TESTING ##############################################  
-  
+  }
+  else {
+    mr  <- abs(diff(z_i))
+    amr <- mean(mr, na.rm = TRUE)
+
+    # Upper limit for moving ranges
+    ulmr <- 3.267 * amr
+
+    # Remove moving ranges greater than ulmr and recalculate amr, Nelson 1982
+    mr  <- mr[mr < ulmr]
+    amr <- mean(mr, na.rm = TRUE)
+
+    sigma_z <- amr / 1.128
+  }
+  # TESTING ##############################################
+
   stdev   <- stdev * sigma_z
-  
+
   # Calculate limits
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
@@ -388,23 +412,23 @@ qic.up <- function(x){
   x$lcl.95       <- x$cl - 2 * stdev
   x$lcl[x$lcl < 0 & is.finite(x$lcl)] <- 0
   x$lcl.95[x$lcl.95 < 0 & is.finite(x$lcl.95)] <- 0
-  
+
   return(x)
 }
 
 qic.g <- function(x){
   base <- x$baseline & x$include
-  
+
   # Calculate centre line
   calccl <- anyNA(x$cl)
   if (anyNA(x$cl)) {
     x$cl <- mean(x$y[base], na.rm = TRUE)
   }
-  
-  
+
+
   # Calculate standard deviation, Montgomery, p. 319
   stdev <- sqrt(x$cl * (x$cl + 1))
-  
+
   # Calculate control limits
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
@@ -412,17 +436,17 @@ qic.g <- function(x){
   x$lcl.95       <- x$cl - 2 * stdev
   x$lcl[x$lcl < 0] <- 0
   x$lcl.95[x$lcl.95 < 0] <- 0
-  
+
   # # Set centre line to theoretical median, Provost (2011) p. 228
   # x$cl <- 0.693 * x$cl
-  
+
   # Set centre line to median
   if(calccl) {
     x$cl <- stats::median(x$y[base], na.rm = TRUE)
   } else {
     x$cl <- 0.693 * x$cl
   }
-  
+
   return(x)
 }
 
@@ -459,7 +483,7 @@ lab.format <- function(x, decimals = 1, percent = FALSE) {
   if (percent) x <- x * 100
   x <- sprintf(paste0("%.", decimals, "f"), x)
   if (percent) x <- paste0(x, '%')
-  
+
   return(x)
 }
 
@@ -469,7 +493,7 @@ makeparts <- function(x, n) {
   x <- x[x >= 0 & x < n]
   x <- x[order(x)]
   x <- rep(c(seq_along(x)), diff(c(x, n)))
-  
+
   return(x)
 }
 
@@ -479,12 +503,12 @@ fixnotes <- function(x) {
   x <- gsub("^\\||\\|$", "", x)
   x <- gsub("\\|", " | ", x)
   x <- gsub("^$", NA, x)
-  
+
   return(x)
 }
 
 # Function for data aggregation and analysis
-qic.agg <- function(d, got.n, part, agg.fun, freeze, exclude, 
+qic.agg <- function(d, got.n, part, agg.fun, freeze, exclude,
                     chart.fun, multiply, dots.only, chart, method, y.neg) {
   d <- d[!is.na(d$x), ]
   d <- split(d, d[,c('x', 'facet1', 'facet2')])
@@ -498,25 +522,25 @@ qic.agg <- function(d, got.n, part, agg.fun, freeze, exclude,
                y.sd     = stats::sd(x$y, na.rm = TRUE),
                n        = sum(x$n, na.rm = got.n),
                y        = ifelse(got.n,
-                                 sum(x$y, na.rm = TRUE) / 
+                                 sum(x$y, na.rm = TRUE) /
                                    sum(x$n, na.rm = got.n),
                                  do.call(agg.fun, list(x$y, na.rm = TRUE))),
                cl       = x$cl[1],
                target   = x$target[1],
                notes    = paste(unique(x$notes), collapse = '|'))
   })
-  
+
   d <- do.call(rbind, d)
-  
-  d <- split(d, d[c('facet1', 'facet2')]) 
+
+  d <- split(d, d[c('facet1', 'facet2')])
   d <- lapply(d, function(x) {
     x$part <- makeparts(part, nrow(x))
     x$xx <- seq_along(x$part)
     x
   })
-  
+
   d <- do.call(rbind, d)
-  
+
   d$baseline <- d$xx <= freeze
   d$include  <- !d$xx %in% exclude
   d$notes    <- fixnotes(d$notes)
@@ -536,9 +560,9 @@ qic.agg <- function(d, got.n, part, agg.fun, freeze, exclude,
     x$target.lab <- ifelse(x$xx == max(x$xx), x$target, NA)
     x
   })
-  
+
   d <- do.call(rbind, c(d, make.row.names = F))
-  
+
   # Remove control lines from missing subgroups
   d$ucl[!is.finite(d$ucl)]         <- NA
   d$ucl.95[!is.finite(d$ucl.95)]   <- NA
@@ -546,22 +570,22 @@ qic.agg <- function(d, got.n, part, agg.fun, freeze, exclude,
   d$lcl.95[!is.finite(d$lcl.95)]   <- NA
   d$lcl.lab[!is.finite(d$lcl.lab)] <- NA
   d$ucl.lab[!is.finite(d$ucl.lab)] <- NA
-  
+
   # Add sigma signals
   d$sigma.signal                        <- d$y > d$ucl | d$y < d$lcl
   d$sigma.signal[is.na(d$sigma.signal)] <- FALSE
-  
+
   # Ignore runs analysis if subgroups are categorical or if chart type is MR
   if (dots.only || chart == 'mr')
     d$runs.signal <- FALSE
-  
+
   # Prevent negative y axis if y.neg argument is FALSE
   if (!y.neg & min(d$y, na.rm = TRUE) >= 0) {
     d$lcl[d$lcl < 0]         <- 0
     d$lcl.95[d$lcl.95 < 0]   <- 0
     d$lcl.lab[d$lcl.lab < 0] <- 0
   }
-  
+
   return(d)
 }
 

--- a/R/helper.functions.R
+++ b/R/helper.functions.R
@@ -5,7 +5,7 @@ runs.analysis <- function(x, method) {
   runs               <- runs[runs != 0 & !is.na(runs)]
   n.useful           <- length(runs)
   n.obs <- length(y)
-
+  
   if (n.useful) {
     run.lengths      <- rle(runs)$lengths
     n.runs           <- length(run.lengths)
@@ -35,31 +35,31 @@ runs.analysis <- function(x, method) {
   x$longest.run.max <- longest.run.max
   x$n.crossings     <- n.crossings
   x$n.crossings.min <- n.crossings.min
-
+  
   return(x)
 }
 
 crsignal <- function(n, c, l, method = c('anhoej', 'bestbox', 'cutbox')) {
   method <- match.arg(method)
-
+  
   if (!(method %in% c('anhoej', 'bestbox', 'cutbox')))
     stop('method should be \"anhoej\", \"bestbox\", or \"cutbox\"')
-
+  
   if ((n < 10 | n > 100) & method != 'anhoej') {
     message('Best box and cut box computations only available for n between ',
             '10 and 100. Using method = "anhoej"')
     method <- 'anhoej'
   }
-
+  
   if(method != 'anhoej')
     message('Runs analysis using ', method, ' method')
-
+  
   if (!(c %in% c(0:n - 1)))
     stop('c should be an integer between 0 and ', n - 1)
-
+  
   if (!(l %in% c(1:n)))
     stop('l should be an integer between 1 and ', n)
-
+  
   bounds <- data.frame(
     n = 10:100,
     cb    = c(  2,  3,  3,  3,  3,  4,  5,  5,  5,  5,  6,  7,  6,
@@ -67,32 +67,32 @@ crsignal <- function(n, c, l, method = c('anhoej', 'bestbox', 'cutbox')) {
                 13, 14, 13, 15, 15, 15, 14, 14, 17, 17, 17, 17, 19,
                 19, 19, 19, 19, 21, 21, 21, 21, 23, 23, 23, 23, 23,
                 25, 25, 26, 26, 27, 27, 27, 28, 29, 29, 29, 30, 30,
-                31, 31, 31, 32, 33, 33, 33, 34, 33, 35, 35, 35, 35,
+                31, 31, 31, 32, 33, 33, 33, 34, 33, 35, 35, 35, 35, 
                 37, 37, 38, 37, 39, 39, 39, 39, 39, 41, 41, 42, 41),
     lb    = c(  6,  7,  6,  6,  6,  7,  8,  7,  7,  7,  7,  8,  7,
                 7,  7,  7,  9,  8,  8,  8, 10,  9,  8,  8,  8,  8,
                 9, 10,  8, 11,  9,  9,  8,  8, 10,  9,  9,  9, 12,
                 10,  9,  9,  9, 11, 10,  9,  9, 12, 10, 10,  9,  9,
                 11, 10, 11, 10, 12, 10, 10, 11, 14, 11, 10, 11, 10,
-                12, 11, 10, 11, 13, 11, 10, 11, 10, 11, 11, 10, 10,
-                12, 11, 12, 10, 13, 11, 11, 10, 10, 12, 11, 12, 10),
+                12, 11, 10, 11, 13, 11, 10, 11, 10, 11, 11, 10, 10, 
+                12, 11, 12, 10, 13, 11, 11, 10, 10, 12, 11, 12, 10), 
     cbord = c(  3,  4, NA, NA, NA,  6,  6, NA,  6,  6, NA, NA,  7,
-                7,  7, NA, 10, 10, 11, NA, 12, 14, NA, 12, 13, NA,
-                15, NA, NA, NA, NA, 17, NA, NA, NA, NA, 19, 20, 20,
+                7,  7, NA, 10, 10, 11, NA, 12, 14, NA, 12, 13, NA, 
+                15, NA, NA, NA, NA, 17, NA, NA, NA, NA, 19, 20, 20, 
                 21, NA, 21, 21, 23, 23, NA, 23, 25, 24, 26, NA, 24,
-                27, 27, 27, 27, 29, NA, 29, 29, 30, 31, 30, 31, NA,
-                32, 34, 33, 33, 37, 35, NA, 36, 36, NA, 38, 36, 38,
+                27, 27, 27, 27, 29, NA, 29, 29, 30, 31, 30, 31, NA, 
+                32, 34, 33, 33, 37, 35, NA, 36, 36, NA, 38, 36, 38, 
                 38, 39, NA, 39, 41, 40, 42, NA, 41, 42, 44, 43, 42),
     lbord = c(  5,  6, NA, NA, NA,  6,  7, NA,  6,  5, NA, NA,  6,
                 6,  6, NA,  7,  7,  7, NA,  9,  8, NA,  7,  7, NA,
-                8, NA, NA, NA, NA,  8, NA, NA, NA, NA,  8,  7, 11,
+                8, NA, NA, NA, NA,  8, NA, NA, NA, NA,  8,  7, 11, 
                 9, NA,  8,  7,  9,  8, NA,  8, 11,  9,  8, NA,  8,
                 9,  9, 10,  9, 10, NA,  8,  8, 13,  9,  9, 10, NA,
                 9,  8,  9,  8, 11,  9, NA, 10,  7, NA,  8,  9,  8,
                 10,  9, NA,  9, 12, 10,  8, NA,  8,  9,  9, 10,  9))
-
+  
   res <- FALSE
-
+  
   if (method == 'anhoej') {
     can <- stats::qbinom(0.05, n - 1, 0.5)
     lan <- round(log2(n)) + 3
@@ -120,7 +120,7 @@ crsignal <- function(n, c, l, method = c('anhoej', 'bestbox', 'cutbox')) {
         res <- FALSE
     }
   }
-
+  
   return(res)
 }
 
@@ -132,7 +132,7 @@ qic.run <- function(x) {
   x$ucl.95 <- as.numeric(NA)
   x$lcl <- as.numeric(NA)
   x$lcl.95 <- as.numeric(NA)
-
+  
   return(x)
 }
 
@@ -140,57 +140,57 @@ qic.i <- function(x) {
   base <- x$baseline & x$include
   if (anyNA(x$cl))
     x$cl <- mean(x$y[base], na.rm = TRUE)
-
+  
   # Average moving range
   mr  <- abs(diff(x$y[base] - x$cl[base]))
   amr <- mean(mr, na.rm = TRUE)
-
+  
   # Upper limit for moving ranges
   ulmr <- 3.267 * amr
-
+  
   # Remove moving ranges greater than ulmr and recalculate amr, Nelson 1982
   mr  <- mr[mr < ulmr]
   amr <- mean(mr, na.rm = TRUE)
-
+  
   # Calculate standard deviation, Montgomery, 6.33
   stdev <- amr / 1.128
-
+  
   # Calculate control limits
   x$lcl <- x$cl - 3 * stdev
   x$lcl.95 <- x$cl - 2 * stdev
   x$ucl <- x$cl + 3 * stdev
   x$ucl.95 <- x$cl + 2 * stdev
-
+  
   return(x)
 }
 
 qic.mr <- function(x) {
   base <- x$baseline & x$include
   x$y  <- c(NA, abs(diff(x$y)))
-
+  
   # Calculate centre line
   if (anyNA(x$cl))
     x$cl <- mean(x$y[base], na.rm = TRUE)
-
+  
   # Calculate upper limit for moving ranges
   x$lcl <- 0
   x$lcl.95 <- 0
   x$ucl <- 3.267 * x$cl
   x$ucl.95 <- (3.267 / 3) * 2 * x$cl
-
+  
   return(x)
 }
 
 qic.xbar <- function(x){
   base  <- x$baseline & x$include
   var.n <- as.logical(length(unique(x$y.length)) - 1)
-
+  
   # Calculate centre line, Montgomery 6.30
   if (anyNA(x$cl)) {
     x$cl <- sum(x$y.length[base] * x$y.mean[base], na.rm = TRUE) /
       sum(x$y.length[base], na.rm = TRUE)
   }
-
+  
   # Calculate standard deviation and control limits, Montgomery 6.29 or 6.31
   if (var.n) {
     stdev <- sqrt(sum((x$y.length[base] - 1) * x$y.sd[base]^2, na.rm = TRUE) /
@@ -204,7 +204,7 @@ qic.xbar <- function(x){
   x$ucl.95 <- x$cl + A3.95 * stdev
   x$lcl <- x$cl - A3 * stdev
   x$lcl.95 <- x$cl - A3.95 * stdev
-
+  
   return(x)
 }
 
@@ -212,7 +212,7 @@ qic.s <- function(x){
   base  <- x$baseline & x$include
   var.n <- as.logical(length(unique(x$y.length)) - 1)
   x$y   <- x$y.sd
-
+  
   # Calculate centre line and control limits
   if (anyNA(x$cl)) {
     if (var.n) { # Variable subgroup size: Montgomery 6.31
@@ -230,7 +230,7 @@ qic.s <- function(x){
   x$ucl.95  <- B4.95 * x$cl
   x$lcl     <- B3 * x$cl
   x$lcl.95  <- B3.95 * x$cl
-
+  
   return(x)
 }
 
@@ -238,11 +238,11 @@ qic.t <- function(x) {
   if (min(x$y, na.rm = TRUE) <= 0) {
     stop('Time between events must be greater than zero')
   }
-
+  
   # Transform y variable and run I chart calculations
   x$y <- x$y^(1 / 3.6)
   x   <- qic.i(x)
-
+  
   # Back transform centre line and control limits
   x$y   <- x$y^3.6
   x$cl  <- x$cl^3.6
@@ -251,21 +251,21 @@ qic.t <- function(x) {
   x$lcl <- x$lcl^3.6
   x$lcl.95 <- x$lcl.95^3.6
   x$lcl[x$lcl < 0 | is.nan(x$lcl)] <- 0
-
+  
   return(x)
 }
 
 qic.p <- function(x) {
   base <- x$baseline & x$include
-
+  
   if (anyNA(x$cl)) {
     x$cl <- sum(x$y.sum[base], na.rm = TRUE) /
       sum(x$n[base], na.rm = TRUE)
   }
-
+  
   # Calculate standard deviation
   stdev <- sqrt(x$cl * (1 - x$cl) / x$n)
-
+  
   # Calculate control limits
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
@@ -275,29 +275,28 @@ qic.p <- function(x) {
   x$ucl.95[x$ucl.95 > 1 & is.finite(x$ucl.95)] <- 1
   x$lcl[x$lcl < 0 & is.finite(x$lcl)] <- 0
   x$lcl.95[x$lcl.95 < 0 & is.finite(x$lcl.95)] <- 0
-
+  
   return(x)
 }
 
 qic.pp <- function(x) {
   base <- x$baseline & x$include
-
+  
   if (anyNA(x$cl)) {
     x$cl <- sum(x$y.sum[base], na.rm = TRUE) /
       sum(x$n[base], na.rm = TRUE)
   }
-
+  
   # Calculate standard deviation
   stdev <- sqrt(x$cl * (1 - x$cl) / x$n)
-
+  
   # Calculate standard deviation for Laney's P prime chart, incorporating
   # between-subgroup variation.
   z_i     <- (x$y[base] - x$cl[base]) / stdev[base]
   # TESTING ##############################################
   if(is.factor(x$x) || is.character(x$x)) {
     sigma_z <- stats::sd(z_i)
-  }
-  else {
+  } else {
     mr  <- abs(diff(z_i))
     amr <- mean(mr, na.rm = TRUE)
 
@@ -310,10 +309,10 @@ qic.pp <- function(x) {
 
     sigma_z <- amr / 1.128
   }
-  # TESTING ##############################################
-
+  # TESTING ##############################################  
+  
   stdev   <- stdev * sigma_z
-
+  
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
   x$lcl          <- x$cl - 3 * stdev
@@ -322,21 +321,21 @@ qic.pp <- function(x) {
   x$ucl.95[x$ucl.95 > 1 & is.finite(x$ucl.95)] <- 1
   x$lcl[x$lcl < 0 & is.finite(x$lcl)] <- 0
   x$lcl.95[x$lcl.95 < 0 & is.finite(x$lcl.95)] <- 0
-
+  
   return(x)
 }
 
 qic.c <- function(x){
   base <- x$baseline & x$include
   x$y <- x$y.sum
-
+  
   if (anyNA(x$cl)) {
     x$cl <- mean(x$y[base], na.rm = TRUE)
   }
-
+  
   # Calculate standard deviation, Montgomery 7.17
   stdev <- sqrt(x$cl)
-
+  
   # Calculate control limits
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
@@ -344,20 +343,20 @@ qic.c <- function(x){
   x$lcl.95       <- x$cl - 2 * stdev
   x$lcl[x$lcl < 0 & is.finite(x$lcl)] <- 0
   x$lcl.95[x$lcl.95 < 0 & is.finite(x$lcl.95)] <- 0
-
+  
   return(x)
 }
 
 qic.u <- function(x){
   base <- x$baseline & x$include
-
+  
   if (anyNA(x$cl)) {
     x$cl   <- sum(x$y.sum[base], na.rm = TRUE) / sum(x$n[base], na.rm = TRUE)
   }
-
+  
   # Calculate standard deviation, Montgomery 7.19
   stdev <- sqrt(x$cl / x$n)
-
+  
   # Calculate control limits
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
@@ -365,30 +364,29 @@ qic.u <- function(x){
   x$lcl.95       <- x$cl - 2 * stdev
   x$lcl[x$lcl < 0 & is.finite(x$lcl)] <- 0
   x$lcl.95[x$lcl.95 < 0 & is.finite(x$lcl.95)] <- 0
-
+  
   return(x)
 }
 
 qic.up <- function(x){
   base <- x$baseline & x$include
-
+  
   if (anyNA(x$cl)) {
     x$cl   <- sum(x$y.sum[base], na.rm = TRUE) / sum(x$n[base], na.rm = TRUE)
   }
-
+  
   # Calculate standard deviation, Montgomery 7.19
   stdev <- sqrt(x$cl / x$n)
-
+  
   # Calculate standard deviation for Laney's u-prime chart, incorporating
   # between-subgroup variation.
   z_i     <- (x$y[base] - x$cl[base]) / stdev[base]
-
+  
   # TESTING ##############################################
   # sigma_z <- mean(abs(diff(z_i)), na.rm = TRUE) / 1.128
   if(is.factor(x$x) || is.character(x$x)) {
     sigma_z <- stats::sd(z_i)
-  }
-  else {
+  } else {
     mr  <- abs(diff(z_i))
     amr <- mean(mr, na.rm = TRUE)
 
@@ -401,10 +399,10 @@ qic.up <- function(x){
 
     sigma_z <- amr / 1.128
   }
-  # TESTING ##############################################
-
+  # TESTING ##############################################  
+  
   stdev   <- stdev * sigma_z
-
+  
   # Calculate limits
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
@@ -412,23 +410,23 @@ qic.up <- function(x){
   x$lcl.95       <- x$cl - 2 * stdev
   x$lcl[x$lcl < 0 & is.finite(x$lcl)] <- 0
   x$lcl.95[x$lcl.95 < 0 & is.finite(x$lcl.95)] <- 0
-
+  
   return(x)
 }
 
 qic.g <- function(x){
   base <- x$baseline & x$include
-
+  
   # Calculate centre line
   calccl <- anyNA(x$cl)
   if (anyNA(x$cl)) {
     x$cl <- mean(x$y[base], na.rm = TRUE)
   }
-
-
+  
+  
   # Calculate standard deviation, Montgomery, p. 319
   stdev <- sqrt(x$cl * (x$cl + 1))
-
+  
   # Calculate control limits
   x$ucl          <- x$cl + 3 * stdev
   x$ucl.95       <- x$cl + 2 * stdev
@@ -436,17 +434,17 @@ qic.g <- function(x){
   x$lcl.95       <- x$cl - 2 * stdev
   x$lcl[x$lcl < 0] <- 0
   x$lcl.95[x$lcl.95 < 0] <- 0
-
+  
   # # Set centre line to theoretical median, Provost (2011) p. 228
   # x$cl <- 0.693 * x$cl
-
+  
   # Set centre line to median
   if(calccl) {
     x$cl <- stats::median(x$y[base], na.rm = TRUE)
   } else {
     x$cl <- 0.693 * x$cl
   }
-
+  
   return(x)
 }
 
@@ -483,7 +481,7 @@ lab.format <- function(x, decimals = 1, percent = FALSE) {
   if (percent) x <- x * 100
   x <- sprintf(paste0("%.", decimals, "f"), x)
   if (percent) x <- paste0(x, '%')
-
+  
   return(x)
 }
 
@@ -493,7 +491,7 @@ makeparts <- function(x, n) {
   x <- x[x >= 0 & x < n]
   x <- x[order(x)]
   x <- rep(c(seq_along(x)), diff(c(x, n)))
-
+  
   return(x)
 }
 
@@ -503,12 +501,12 @@ fixnotes <- function(x) {
   x <- gsub("^\\||\\|$", "", x)
   x <- gsub("\\|", " | ", x)
   x <- gsub("^$", NA, x)
-
+  
   return(x)
 }
 
 # Function for data aggregation and analysis
-qic.agg <- function(d, got.n, part, agg.fun, freeze, exclude,
+qic.agg <- function(d, got.n, part, agg.fun, freeze, exclude, 
                     chart.fun, multiply, dots.only, chart, method, y.neg) {
   d <- d[!is.na(d$x), ]
   d <- split(d, d[,c('x', 'facet1', 'facet2')])
@@ -522,25 +520,25 @@ qic.agg <- function(d, got.n, part, agg.fun, freeze, exclude,
                y.sd     = stats::sd(x$y, na.rm = TRUE),
                n        = sum(x$n, na.rm = got.n),
                y        = ifelse(got.n,
-                                 sum(x$y, na.rm = TRUE) /
+                                 sum(x$y, na.rm = TRUE) / 
                                    sum(x$n, na.rm = got.n),
                                  do.call(agg.fun, list(x$y, na.rm = TRUE))),
                cl       = x$cl[1],
                target   = x$target[1],
                notes    = paste(unique(x$notes), collapse = '|'))
   })
-
+  
   d <- do.call(rbind, d)
-
-  d <- split(d, d[c('facet1', 'facet2')])
+  
+  d <- split(d, d[c('facet1', 'facet2')]) 
   d <- lapply(d, function(x) {
     x$part <- makeparts(part, nrow(x))
     x$xx <- seq_along(x$part)
     x
   })
-
+  
   d <- do.call(rbind, d)
-
+  
   d$baseline <- d$xx <= freeze
   d$include  <- !d$xx %in% exclude
   d$notes    <- fixnotes(d$notes)
@@ -560,9 +558,9 @@ qic.agg <- function(d, got.n, part, agg.fun, freeze, exclude,
     x$target.lab <- ifelse(x$xx == max(x$xx), x$target, NA)
     x
   })
-
+  
   d <- do.call(rbind, c(d, make.row.names = F))
-
+  
   # Remove control lines from missing subgroups
   d$ucl[!is.finite(d$ucl)]         <- NA
   d$ucl.95[!is.finite(d$ucl.95)]   <- NA
@@ -570,22 +568,22 @@ qic.agg <- function(d, got.n, part, agg.fun, freeze, exclude,
   d$lcl.95[!is.finite(d$lcl.95)]   <- NA
   d$lcl.lab[!is.finite(d$lcl.lab)] <- NA
   d$ucl.lab[!is.finite(d$ucl.lab)] <- NA
-
+  
   # Add sigma signals
   d$sigma.signal                        <- d$y > d$ucl | d$y < d$lcl
   d$sigma.signal[is.na(d$sigma.signal)] <- FALSE
-
+  
   # Ignore runs analysis if subgroups are categorical or if chart type is MR
   if (dots.only || chart == 'mr')
     d$runs.signal <- FALSE
-
+  
   # Prevent negative y axis if y.neg argument is FALSE
   if (!y.neg & min(d$y, na.rm = TRUE) >= 0) {
     d$lcl[d$lcl < 0]         <- 0
     d$lcl.95[d$lcl.95 < 0]   <- 0
     d$lcl.lab[d$lcl.lab < 0] <- 0
   }
-
+  
   return(d)
 }
 


### PR DESCRIPTION
According to Provost & Murray (2011), when calculating the correction factor for u-prime and p-prime charts from the z-score moving ranges, these moving ranges should first be screened for outliers - as is done for the i-chart:

![image](https://user-images.githubusercontent.com/27717896/165875262-e6b5582c-08ae-4be3-9417-8d966a1fa742.png)

This PR adds that screening to the p-prime and u-prime chart calculations


Provost, L. P., & Murray, S. (2011). The health care data guide: learning from data for improvement. John Wiley & Sons.